### PR TITLE
Fixed retain cycle

### DIFF
--- a/RCRScheduledTask/RCRScheduledTask.m
+++ b/RCRScheduledTask/RCRScheduledTask.m
@@ -31,8 +31,9 @@
         _minutesOnWhichToExecute = [[[RCRScheduleStringParser alloc] init] minutesFromScheduleString:scheduleString];
         _lastExecuted = nil;
 
+        __weak typeof(self) weakSelf = self;
         _minuteChangeTimer = [RCRMinuteChangeTimer timerWithBlock:^ (NSDate *firingDate) {
-            [self timerFiredWithFiringDate:firingDate];
+            [weakSelf timerFiredWithFiringDate:firingDate];
         }];
     }
     


### PR DESCRIPTION
Quick fix to a retain cycle issue that happens because `self` is retained by a retained block.